### PR TITLE
Fixes #37982 - Fix error when importing templates with `-v`

### DIFF
--- a/lib/hammer_cli_foreman_templates/import.rb
+++ b/lib/hammer_cli_foreman_templates/import.rb
@@ -30,7 +30,7 @@ module HammerCLIForemanTemplates
       templates = send_request['templates']
       if option_verbose
         templates.each do |template|
-          if template['validation_errors'].empty?
+          if template['validation_errors'].to_a.empty?
             template['validation_errors'] = nil
           else
             validation_errors = []


### PR DESCRIPTION
I am doing this fix as a part of implementing new feature but this issue might not be necessarily related to the new parameters and could just be an uncaugt error that already existed. Through testing I found that `template['validation_errors']` is sometimes nil instead of an empty array so the condition needs adjusting.