### PR TITLE
Relax hammer_cli_foreman dependency to allow 5.x

### DIFF
--- a/hammer_cli_foreman_templates.gemspec
+++ b/hammer_cli_foreman_templates.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency 'hammer_cli_foreman', '>= 3.0.0', '< 4.0.0'
+  s.add_dependency 'hammer_cli_foreman', '>= 3.0.0', '< 6.0.0'
 
   s.required_ruby_version = '>= 2.7', '< 4'
 end


### PR DESCRIPTION
## Summary
- Relax the hammer_cli_foreman version constraint to < 6.0.0 to allow compatibility with the upcoming 5.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)